### PR TITLE
Introduce associated type `Input` in trait `SignatureScheme`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secret-storage"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["IOTA Stiftung"]
 homepage = "https://www.iota.org"

--- a/src/signature_scheme.rs
+++ b/src/signature_scheme.rs
@@ -5,4 +5,5 @@
 pub trait SignatureScheme {
     type PublicKey;
     type Signature;
+    type Input;
 }

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -15,7 +15,10 @@ use crate::SignatureScheme;
 #[cfg_attr(feature = "send-sync-storage", async_trait)]
 pub trait Signer<K: SignatureScheme> {
     type KeyId;
-    async fn sign(&self, data: &[u8]) -> Result<K::Signature>;
+
+    async fn sign(&self, data: &K::Input) -> Result<K::Signature>;
+
     async fn public_key(&self) -> Result<K::PublicKey>;
+
     fn key_id(&self) -> &Self::KeyId;
 }


### PR DESCRIPTION
# Description of change
Adds associated type `Input` to trait `SignatureScheme` in order to let the scheme decide the type of the data to sign in `Signer`.
