### PR TITLE
Update signer's key_id getter to return `KeyId` instance instead of link

### DIFF
--- a/src/signer.rs
+++ b/src/signer.rs
@@ -20,5 +20,5 @@ pub trait Signer<K: SignatureScheme> {
 
     async fn public_key(&self) -> Result<K::PublicKey>;
 
-    fn key_id(&self) -> &Self::KeyId;
+    fn key_id(&self) -> Self::KeyId;
 }


### PR DESCRIPTION
# Description of change

<!-- Please write a summary of your changes and why you made them. -->

Updates `Signer` trait's `key_id` getter to return `Self::KeyId` instance instead of a reference. This makes the getter more flexible, especially in cases, where the key id instance is not owned by the signer, and a reference would have to be created "on the fly".

## Type of change

<!-- Choose a type of change, and delete any options that are not relevant. -->

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

<!-- Describe the tests that you ran to verify your changes. -->

<!-- Make sure to provide instructions for the maintainer as well as any relevant configurations. -->

Compiled locally. Ran tests in [identity.rs](https://github.com/iotaledger/identity.rs), that consumes the updated `Signer` trait.

## Change checklist

<!-- Tick the boxes that are relevant to your changes, and delete any items that are not. -->

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing unit tests pass locally with my changes
